### PR TITLE
Add type stub config for Mypy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,6 +144,8 @@ venv.bak/
 .mypy_cache/
 .dmypy.json
 dmypy.json
+# cf. https://mypy.readthedocs.io/en/stable/stubgen.html#stubgen --output
+stubs/
 
 # Pyre type checker
 .pyre/

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -2,3 +2,5 @@
 ; cf. https://mypy.readthedocs.io/en/stable/existing_code.html#introduce-stricter-options
 [mypy]
 strict = True
+; cf. https://mypy.readthedocs.io/en/stable/config_file.html#confval-mypy_path
+mypy_path = $MYPY_CONFIG_FILE_DIR/stubs


### PR DESCRIPTION
※ If a package import statement displays `module is installed, but missing library stubs or py.typed`, type stub files may be generated using `stubgen` offered by Mypy.