### PR TITLE
Update Renovate config for PR grouping

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -8,5 +8,35 @@
   "labels": ["dependencies"],
   "timezone": "Asia/Tokyo",
   "prConcurrentLimit": 0,
-  "prHourlyLimit": 0
+  "prHourlyLimit": 0,
+  "packageRules": [
+    {
+      "matchPackagePatterns": ["poetry"],
+      "matchDepTypes": ["dev-dependencies"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "poetry dev-dependencies (non-major)",
+      "labels": ["poetry", "dev-dependencies"]
+    },
+    {
+      "matchPackagePatterns": ["npm"],
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "groupName": "npm devDependencies (non-major)",
+      "labels": ["npm", "dev-dependencies"]
+    },
+    {
+      "matchPackagePatterns": ["poetry"],
+      "matchDepTypes": ["dependencies"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "poetry dependencies (major)",
+      "labels": ["poetry", "dependencies"]
+    },
+    {
+      "matchPackagePatterns": ["npm"],
+      "matchDepTypes": ["dependencies"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "npm dependencies (major)",
+      "labels": ["npm", "dependencies"]
+    }
+  ]
 }


### PR DESCRIPTION
> All updates sharing the same groupName will be placed into the same branch/PR. For example, to group all non-major devDependencies updates together into a single PR:

- https://docs.renovatebot.com/modules/manager/poetry
- https://docs.renovatebot.com/configuration-options/#groupname